### PR TITLE
Add Playwright testing setup with basic redirect test

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "start": "next start",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
-    "snapshot:rpp": "node scripts/rpp-snapshot.mjs"
+    "snapshot:rpp": "node scripts/rpp-snapshot.mjs",
+    "test": "playwright test"
   },
   "dependencies": {
     "@genkit-ai/googleai": "^1.14.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: 'tests',
+  use: {
+    baseURL: 'http://localhost:3000',
+  },
+  webServer: {
+    command: 'npm run dev',
+    port: 3000,
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/tests/home.spec.ts
+++ b/tests/home.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('redirects home to dashboard', async ({ page }) => {
+  await page.goto('/');
+  await expect(page).toHaveURL(/\/dashboard/);
+});


### PR DESCRIPTION
## Summary
- add Playwright configuration and npm test script
- include initial redirect test verifying home route forwards to dashboard

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b63d62905c8331bcdb0aad634626b0