### PR TITLE
Add mock user ID to goal tracker goals

### DIFF
--- a/src/components/dashboard/goal-tracker.tsx
+++ b/src/components/dashboard/goal-tracker.tsx
@@ -12,9 +12,9 @@ import { PlusCircle } from 'lucide-react';
 import type { Goal } from '@/lib/types';
 
 const mockGoals: Goal[] = [
-  { id: '1', name: 'Dream Vacation to Bali', targetAmount: 4000, currentAmount: 2800, imageUrl: 'https://picsum.photos/600/400', imageHint: 'travel beach' },
-  { id: '2', name: 'New MacBook Pro', targetAmount: 2500, currentAmount: 1000, imageUrl: 'https://picsum.photos/600/400', imageHint: 'tech computer' },
-  { id: '3', name: 'Emergency Fund', targetAmount: 10000, currentAmount: 9500, imageUrl: 'https://picsum.photos/600/400', imageHint: 'safety security' },
+  { id: '1', userId: 'mock-user-id', name: 'Dream Vacation to Bali', targetAmount: 4000, currentAmount: 2800, imageUrl: 'https://picsum.photos/600/400', imageHint: 'travel beach' },
+  { id: '2', userId: 'mock-user-id', name: 'New MacBook Pro', targetAmount: 2500, currentAmount: 1000, imageUrl: 'https://picsum.photos/600/400', imageHint: 'tech computer' },
+  { id: '3', userId: 'mock-user-id', name: 'Emergency Fund', targetAmount: 10000, currentAmount: 9500, imageUrl: 'https://picsum.photos/600/400', imageHint: 'safety security' },
 ];
 
 export function GoalTracker() {


### PR DESCRIPTION
## Summary
- add `userId` field to each mock goal in goal tracker

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(interactive config prompt prevents completion)*
- `npm run typecheck` *(fails: cannot find module '@/features/col/AdvancedAssumptionsPanel', and other TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b651cef7c08331b8e6a6419bd7abe5