### PR TITLE
Add Playwright test setup and initial redirect check

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "start": "next start",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
-    "snapshot:rpp": "node scripts/rpp-snapshot.mjs"
+    "snapshot:rpp": "node scripts/rpp-snapshot.mjs",
+    "test": "playwright test"
   },
   "dependencies": {
     "@genkit-ai/googleai": "^1.14.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  webServer: {
+    command: 'npm run dev',
+    port: 3000,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120 * 1000,
+  },
+  use: {
+    baseURL: 'http://localhost:3000',
+  },
+});

--- a/tests/redirect.spec.ts
+++ b/tests/redirect.spec.ts
@@ -1,0 +1,7 @@
+import { test, expect } from '@playwright/test';
+
+// Basic smoke test to ensure the landing page redirect works.
+test('home redirects to dashboard', async ({ page }) => {
+  await page.goto('/');
+  await expect(page).toHaveURL(/\/dashboard/);
+});


### PR DESCRIPTION
## Summary
- add npm test script to run Playwright
- configure Playwright with web server for dev
- add redirect smoke test verifying home page goes to dashboard

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b652ed51b88331bcdad35b6e56f563